### PR TITLE
Update of deprecated plugins

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,14 +23,14 @@ config_plugin = @DAGOLDEN ; my own plugin allows Pod::WikiDoc
 [CopyReadmeFromBuild]       ; for the repo
 
 ; t tests
-[CompileTests]      ; make sure .pm files all compile
+[Test::Compile]     ; make sure .pm files all compile
 fake_home = 1       ; fakes $ENV{HOME} just in case
 
 ; xt tests
 [MetaTests]         ; xt/release/meta-yaml.t
 [PodSyntaxTests]    ; xt/release/pod-syntax.t
 [PodCoverageTests]  ; xt/release/pod-coverage.t
-[PortabilityTests]  ; xt/release/portability.t (of file name)
+[Test::Portability] ; xt/release/portability.t (of file name)
 [KwaliteeTests]     ; xt/release/kwalitee.t
 [Test::Version]     ; xt/release/test-version.t
 


### PR DESCRIPTION
On my "place-in-space" setup, this distro failed the `00-compile.t` test because it string-interpolated `$^X` rather than quote-protecting or using a list form. The latest, non-deprecated plugins don't get it wrong. Please could you merge this, then re-release the distro?